### PR TITLE
Deployment code and complete removal of /check command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,7 +11,7 @@ from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, ReplyKeybo
 HOST = "covid-fake-news-backend.herokuapp.com"
 # HOST = "0.0.0.0:8080"
 TOKEN = config.TOKEN
-#PORT = int(os.environ.get('PORT', '8443'))
+PORT = int(os.environ.get('PORT', '8443'))
 bot = Bot(token=TOKEN)
 loaded_json = {}
 
@@ -131,9 +131,9 @@ def main():
     dp.add_handler(CommandHandler('start', start))
     dp.add_handler(MessageHandler(Filters.text, verify))
     dp.add_handler(CallbackQueryHandler(button))
-    updater.start_polling()
-    #updater.start_webhook(listen="0.0.0.0",port=PORT,url_path=TOKEN)
-    #updater.bot.set_webhook("https://hidden-reef-68700.herokuapp.com/" + TOKEN)
+    #updater.start_polling()
+    updater.start_webhook(listen="0.0.0.0",port=PORT,url_path=TOKEN)
+    updater.bot.set_webhook("https://hidden-reef-68700.herokuapp.com/" + TOKEN)
     updater.idle()
 
 

--- a/bot.py
+++ b/bot.py
@@ -51,7 +51,7 @@ def updateVote(host, isTrueVote):
 
 def start(update, context):
     context.bot.send_message(chat_id=update.effective_chat.id,
-                             text="Send me a message using /check, we'll see if its real or not!")
+                             text="Send me a message, we'll see if its real or not!")
 
 
 def verify(update, context):

--- a/bot.py
+++ b/bot.py
@@ -5,11 +5,12 @@ import string
 import os
 import requests
 import json
-from telegram.ext import *
+from telegram.ext import Updater, Dispatcher, Filters, CallbackQueryHandler, CommandHandler, MessageHandler 
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, ReplyKeyboardRemove
 
 HOST = "covid-fake-news-backend.herokuapp.com"
 # HOST = "0.0.0.0:8080"
+# TOKEN = os.getenv('TOKEN')
 TOKEN = config.TOKEN
 PORT = int(os.environ.get('PORT', '8443'))
 bot = Bot(token=TOKEN)
@@ -131,9 +132,11 @@ def main():
     dp.add_handler(CommandHandler('start', start))
     dp.add_handler(MessageHandler(Filters.text, verify))
     dp.add_handler(CallbackQueryHandler(button))
-    #updater.start_polling()
-    updater.start_webhook(listen="0.0.0.0",port=PORT,url_path=TOKEN)
-    updater.bot.set_webhook("https://hidden-reef-68700.herokuapp.com/" + TOKEN)
+
+    updater.start_polling()
+    #updater.start_webhook(listen="0.0.0.0",port=PORT,url_path=TOKEN)
+    #updater.bot.set_webhook("https://fakenewsbusterbot.herokuapp.com/" + TOKEN)
+    
     updater.idle()
 
 

--- a/bot.py
+++ b/bot.py
@@ -124,16 +124,15 @@ def button(update, context):
 
 # MAIN FUNCTION
 
-
 def main():
     updater = Updater(TOKEN, use_context=True)
     dp = updater.dispatcher
-
+    
+    dp.add_handler(CommandHandler('start', start))
     dp.add_handler(MessageHandler(Filters.text, verify))
     dp.add_handler(CallbackQueryHandler(button))
-    dp.add_handler(CommandHandler('start', start))
     updater.start_polling()
-    # updater.start_webhook(listen="0.0.0.0",port=PORT,url_path=TOKEN)
+    #updater.start_webhook(listen="0.0.0.0",port=PORT,url_path=TOKEN)
     #updater.bot.set_webhook("https://hidden-reef-68700.herokuapp.com/" + TOKEN)
     updater.idle()
 


### PR DESCRIPTION
1) Read TOKEN from environment variable TOKEN as per Heroku standards.
2) Import individual elements instead of using wildcard for telegram.ext module
3) Removed mention of /check command from /start command.